### PR TITLE
解决android下，底部弹窗会被底部导航栏遮住问题

### DIFF
--- a/source/UI.Dialog.pas
+++ b/source/UI.Dialog.pas
@@ -3283,6 +3283,7 @@ begin
   FLayBubble.Padding.Assign(StyleMgr.FBackgroundPadding);
   {$IFDEF ANDROID}
   FLayBubble.Margins.Top := FLayBubble.Margins.Top + TView.GetStatusHeight;
+  FLayBubble.Margins.Bottom := FLayBubble.Margins.Bottom + TView.GetNavigationBarHeight;
   {$ENDIF}
   if (FDialog.Builder.FPosition = TDialogViewPosition.Bottom) and (FDialog.Builder.CancelButtonText <> '') then
     FLayBubbleBottom := InitLayBubble('LayBubbleBottom', TDialogViewPosition.Bottom);


### PR DESCRIPTION
1、解决android下，底部弹窗会被底部导航栏遮住问题；
2、特别是弹窗的按钮会被遮住，导致无法点击。