### PR TITLE
Fix: Remove deprecated TAniCalculations.Interval for Delphi 13 Florence compatibility

### DIFF
--- a/source/UI.Calendar.pas
+++ b/source/UI.Calendar.pas
@@ -939,7 +939,9 @@ begin
   FAniCalc.ViewportPositionF := PointF(0, 0);
   FAniCalc.Animation := True;
   FAniCalc.Averaging := True;
+  {$IF CompilerVersion < 37.0}
   FAniCalc.Interval := 8;
+  {$ENDIF}
   FAniCalc.BoundsAnimation := True;
   FAniCalc.TouchTracking := [ttHorizontal];
   FAniCalc.OnChanged := AniCalcChange;

--- a/source/UI.Standard.pas
+++ b/source/UI.Standard.pas
@@ -3034,7 +3034,9 @@ end;
 function TScrollView.CreateAniCalculations: TScrollCalculations;
 begin
   Result := TScrollCalculations.Create(Self);
+  {$IF CompilerVersion < 37.0}
   Result.Interval := PhysicsProcessingInterval;
+  {$ENDIF}
   Result.OnChanged := AniCalcChange;
   Result.OnStart := AniCalcChange;
   Result.OnStop := AniCalcChange;
@@ -5926,7 +5928,9 @@ begin
   FAniCalc.ViewportPositionF := PointF(0, 0);
   FAniCalc.Animation := True;
   FAniCalc.Averaging := True;
+  {$IF CompilerVersion < 37.0}
   FAniCalc.Interval := 8;
+  {$ENDIF}
   FAniCalc.BoundsAnimation := True;
   FAniCalc.TouchTracking := [ttHorizontal, ttVertical];
   FAniCalc.OnChanged := AniCalcChange;


### PR DESCRIPTION
Delphi 13 (Florence) removed the TAniCalculations.Interval property, replacing it with a display link–based timing system. This patch adds compiler version guards to preserve backward compatibility with earlier Delphi versions while preventing build errors in Florence.